### PR TITLE
Change the detail of reading the Cookie value

### DIFF
--- a/cookies.js
+++ b/cookies.js
@@ -46,7 +46,7 @@ var cookies = function (data, opt) {
       .map(opt.autoencode ? opt.decode : function (d) { return d; })
       .map(function (part) { return part.split('='); })
       .reduce(function (parts, part) {
-        parts[part[0]] = part[1];
+        parts[part[0]] = part.splice(1).join('=');
         return parts;
       }, {})[data];
     if (!opt.autojson) return value;


### PR DESCRIPTION
Firstly, I praise your code after I read source code of `cookies.js`. I learned a lot from it and thanks a lot.

Then, I begin use `cookies.js` in my company projects. But I found some questions when I read the cookie like this:

```
MCITY=224-224%3A; 
BD_HOME=1; 
H_PS_PSSID=1468_17948_21113_18559_17001_21454_21409_21377_21525_21190_20928; 
CNUSER=userid=1&&nickName=xxx&loginType=1&token=666;
```

Maybe you will say:

> This `CNUSER` cookie value should be encode.

But this cookie has been used in many other sites in my company, so I could not ask my partner to change this (Maybe the author of this cookie is my boss)

From my partner, they said past days they used [`jquery.cookie.js`](https://github.com/carhartl/jquery-cookie) works well, but nowadays we begin use `React.js`, so I wanna use `Cookies.js` but we met the previous bug. When I read the source code again, I found the question:

Use

```
parts[part[0]] = part.splice(1).join('=');
```

to

```
parts[part[0]] = part[1];
```

I like the use of `Array.prototype.reduce`, so I still wanna keep it.

Also many other ways:

In `jquery.cookie.js`:

```
var cookies = document.cookie ? document.cookie.split('; ') : [],
    i = 0,
    l = cookies.length;
for (; i < l; i++) {
    var parts = cookies[i].split('='),
        name = decode(parts.shift()),
        cookie = parts.join('=');
}
```

Another:

```
var cookies = document.cookie ? document.cookie.split('; ') : [],
    i = 0,
    l = cookies.length;
for (; i < l; i++) {
    var index = cookies[i].indexOf('='),
        name = decode(cookies[i].slice(0, index)),
        cookie = cookies[i].slice(index + 1);
}
```

Hope you can accept my advice or may catch and throw an error when met `=` many times.
Best wishes.
